### PR TITLE
Change verses class to update in verse of the day  file to fix passage bug

### DIFF
--- a/src/verseOfTheDay.ts
+++ b/src/verseOfTheDay.ts
@@ -11,7 +11,7 @@ export async function getVerseOfTheDay() {
         const citationsArray: Array<String> = [];
         const imageArray: Array<String> = [];
 
-        const verses = $("a.text-gray-50");
+        const verses = $("a.text-text-light.w-full.no-underline");
         const citations = $("p.text-gray-25");
         const images = $("a.block");
 


### PR DESCRIPTION
The former verses array was wrong, the passage kept returning home so i went to the url, and checked the appropriate classe to this 
```
const verses = $("a.text-text-light.w-full.no-underline");
```